### PR TITLE
Release v0.2.1

### DIFF
--- a/git_railway/model.py
+++ b/git_railway/model.py
@@ -309,6 +309,12 @@ def arrange_commits(
                         LOGGER.debug(f"      need a new level: m = {m}, x = {x}")
                 elif not commits[p.hexsha][1]:  # parent has no refs
                     x = locations[p.hexsha][0]  # use parent level
+                elif any(
+                    {r for r, j in refs_levels.items() if j == i and r in current_refs}
+                    == current_refs
+                    for i in {l for _, l in refs_levels.items()}
+                ):
+                    x = refs_levels[next(iter(current_refs))]
                 else:
                     x = gap()
                     LOGGER.debug(f"    new level: {x}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-railway"
-version = "0.2.0"
+version = "0.2.1"
 description = "Visualise local git branches as neat interactive HTML pages"
 authors = ["Gabriele N. Tornetta <phoenix1987@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
# Bugfixes

Re-used branch levels as much as possible, especially when coming from a parent with no refs but going to an active branch.

Switched to iterative traversal of the commit graph to avoid call stack overflow from recursion.